### PR TITLE
Fix error involving async_migrate_engine.

### DIFF
--- a/custom_components/groq_cloud_api/conversation.py
+++ b/custom_components/groq_cloud_api/conversation.py
@@ -106,9 +106,6 @@ class GroqConversationEntity(
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
-        assist_pipeline.async_migrate_engine(
-            self.hass, "conversation", self.entry.entry_id, self.entity_id
-        )
         conversation.async_set_agent(self.hass, self.entry, self)
         self.entry.async_on_unload(
             self.entry.add_update_listener(self._async_entry_update_listener)


### PR DESCRIPTION
An error arose in the latest versions of Home Assistant, where the `assist_pipeline` object no longer had the property `async_migrate_engine`. Simply removing this call fixed the subsequent error while preserving functionality.