### PR TITLE
Replace BASE_PROMPT by DATE_TIME_PROMPT

### DIFF
--- a/custom_components/groq_cloud_api/conversation.py
+++ b/custom_components/groq_cloud_api/conversation.py
@@ -186,7 +186,7 @@ class GroqConversationEntity(
         try:
             prompt_parts = [
                 template.Template(
-                    llm.BASE_PROMPT
+                    llm.DATE_TIME_PROMPT
                     + options.get(CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT),
                     self.hass,
                 ).async_render(

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Groq Cloud API",
     "render_readme": true,
-    "homeassistant": "2024.6.0"
+    "homeassistant": "2025.11.0"
   }


### PR DESCRIPTION
This custom integration is failing since the last Home Assistant upgrade to 2025.11.0.

Apparently, they removed the variable `BASE_PROMPT` from the homeassistant.helpers.llm class and renamed it to `DATE_TIME_PROMPT`. See commit here: https://github.com/home-assistant/core/commit/34ab725b7500676208bcb7f24127968c3db5e3be

Error:

```
Unexpected error during intent recognition
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/pipeline.py", line 1297, in recognize_intent
    conversation_result = await conversation.async_converse(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/components/conversation/agent_manager.py", line 126, in async_converse
    result = await method(conversation_input)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/conversation/entity.py", line 55, in internal_async_process
    return await self.async_process(user_input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/groq_cloud_api/conversation.py", line 192, in async_process
    llm.BASE_PROMPT
AttributeError: module 'homeassistant.helpers.llm' has no attribute 'BASE_PROMPT'
```

This PR fixes the issue. This has been tested on my HA.

This is a breaking change! It won't work on versions <2025.11.0 !

Closes #10