### PR TITLE
Allow to choose the reasoning effort for supported models

### DIFF
--- a/custom_components/groq_cloud_api/config_flow.py
+++ b/custom_components/groq_cloud_api/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
+    CONF_REASONING_EFFORT,
     CONF_TEMPERATURE,
     CONF_TOP_P,
     DEFAULT_NAME,
@@ -274,6 +275,38 @@ class GroqOptionsFlow(OptionsFlow):
                 default=options.get(CONF_TEMPERATURE, RECOMMENDED_TEMPERATURE),
             ): NumberSelector(NumberSelectorConfig(min=0, max=2, step=0.05)),
         }
+
+        reasoning_options: list[str] | None = None
+        if current_model.startswith("qwen/qwen3-32b"):
+            reasoning_options = ["default", "none"]
+        elif current_model.startswith(
+            (
+                "openai/gpt-oss-20b",
+                "openai/gpt-oss-120b",
+                "openai/gpt-oss-safeguard-20b",
+            )
+        ):
+            reasoning_options = ["low", "medium", "high"]
+
+        if reasoning_options:
+            selected_reasoning = options.get(CONF_REASONING_EFFORT)
+            if selected_reasoning not in reasoning_options:
+                selected_reasoning = reasoning_options[0]
+            schema[
+                vol.Optional(
+                    CONF_REASONING_EFFORT,
+                    description={"suggested_value": options.get(CONF_REASONING_EFFORT)},
+                    default=selected_reasoning,
+                )
+            ] = SelectSelector(
+                SelectSelectorConfig(
+                    options=reasoning_options,
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            )
+        elif CONF_REASONING_EFFORT in options:
+            options = dict(options)
+            options.pop(CONF_REASONING_EFFORT, None)
 
         return schema
 

--- a/custom_components/groq_cloud_api/const.py
+++ b/custom_components/groq_cloud_api/const.py
@@ -14,6 +14,7 @@ DEFAULT_CONVERSATION_NAME = "Groq Conversation"
 CONF_PROMPT = "prompt"
 CONF_CHAT_MODEL = "chat_model"
 RECOMMENDED_CHAT_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct"
+CONF_REASONING_EFFORT = "reasoning_effort"
 CONF_MAX_TOKENS = "max_tokens"
 RECOMMENDED_MAX_TOKENS = 300
 CONF_TOP_P = "top_p"


### PR DESCRIPTION
Hello Hunor,

one more thing I noticed:
The gpt-oss models often tend to to produce a little bit rubbish when you have a large prompt and a lot tools combined with short questions that also should result in short replies.

E.g. is asking about the current time or date.
They often start to loop the result and repeat the answer twice or three times.

Sometimes you also get reasoning text in the reply, so you see lengthy responses where it's talking with itself. 😉

Seems like a often seen problem based on community posts in the groq forums and the Ollama community.
A often recommended fix is to set reasoning to low for this models.
According to my tests, that really seems to help. 

So I added this to the two model types where reasoning settings are possible with groq: Qwen 3 32B and the gpt-oss models.
They have a little bit different reasoning settings, which is respected in this PR.

You can find details here if needed:
https://console.groq.com/docs/reasoning

The changes will add a reasoning setting to the model options of your integration:
<img width="463" height="387" alt="image" src="https://github.com/user-attachments/assets/c306e630-4ad3-4560-83dc-1312280c2f5e" />

It will be hidden (and the settings not sent to the API) for models that don't support it.