### PR TITLE
Allow multiple selection for LLM HASS API

### DIFF
--- a/custom_components/groq_cloud_api/config_flow.py
+++ b/custom_components/groq_cloud_api/config_flow.py
@@ -296,7 +296,7 @@ class GroqOptionsFlow(OptionsFlow):
             vol.Optional(
                 CONF_LLM_HASS_API,
                 description={"suggested_value": options.get(CONF_LLM_HASS_API)},
-            ): SelectSelector(SelectSelectorConfig(options=hass_apis)),
+            ): SelectSelector(SelectSelectorConfig(options=hass_apis, multiple=True)),
             vol.Required(
                 CONF_CHAT_MODEL,
                 default=current_model,


### PR DESCRIPTION
Hey @HunorLaczko 

I hope you are well. 

I have implemented the change from https://github.com/HunorLaczko/ha-groq-cloud-api/issues/21 and tested it myself. 

Works well. No more changes are needed to make this work since Home Assistant core (as of 2024.6+) natively handles the merging of multiple LLM APIs... we just needed to give the user the choice :)

Thanks again for all the hard work!

